### PR TITLE
Make GitHub recognize Forth and C files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.f83 linguist-language=Forth
+*.tst linguist-language=Forth
+*.v  linguist-language=c


### PR DESCRIPTION
Hello,

This makes GitHub recognize the `.f83`, `.tst`, and `.v` files correctly.